### PR TITLE
Removes Build Warnings

### DIFF
--- a/curve/ed25519/additions/curve_sigs.c
+++ b/curve/ed25519/additions/curve_sigs.c
@@ -7,7 +7,7 @@ void curve25519_keygen(unsigned char* curve25519_pubkey_out,
                        const unsigned char* curve25519_privkey_in)
 {
   ge_p3 ed; /* Ed25519 pubkey point */
-  fe ed_y, ed_y_plus_one, one_minus_ed_y, inv_one_minus_ed_y;
+  fe ed_y_plus_one, one_minus_ed_y, inv_one_minus_ed_y;
   fe mont_x;
 
   /* Perform a fixed-base multiplication of the Edwards base point,

--- a/curve/ed25519/additions/zeroize.c
+++ b/curve/ed25519/additions/zeroize.c
@@ -3,14 +3,14 @@
 void zeroize(unsigned char* b, size_t len)
 {
   size_t count = 0;
-  unsigned long retval = 0;
+  //unsigned long retval = 0;
   volatile unsigned char *p = b;
 
   for (count = 0; count < len; count++)
     p[count] = 0;
 }
 
-void zeroize_stack()
+void zeroize_stack(void)
 {
   unsigned char m[ZEROIZE_STACK_SIZE];
   zeroize(m, sizeof m);

--- a/curve/ed25519/additions/zeroize.h
+++ b/curve/ed25519/additions/zeroize.h
@@ -7,6 +7,6 @@
 
 void zeroize(unsigned char* b, size_t len);
 
-void zeroize_stack();
+void zeroize_stack(void);
 
 #endif

--- a/curve25519module.c
+++ b/curve25519module.c
@@ -47,7 +47,8 @@ calculateSignature(PyObject *self, PyObject *args)
         return NULL;
     }
 
-   curve25519_sign(signature, privatekey, message, messagelen, random);
+    curve25519_sign((unsigned char *)signature, (unsigned char *)privatekey, 
+                    (unsigned char *)message, messagelen, (unsigned char *)random);
 
    return PyBytes_FromStringAndSize((char *)signature, 64);
 }
@@ -73,7 +74,8 @@ verifySignature(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    int result = curve25519_verify(signature, publickey, message, messagelen);
+    int result = curve25519_verify((unsigned char *)signature, (unsigned char *)publickey, 
+                                   (unsigned char *)message, messagelen);
 
     return Py_BuildValue("i", result);
 


### PR DESCRIPTION
Hi, currently I'm working to get python-axolotl-curve25519 and python-axoltl as well  into the Debian main archive. 
In order to keep a clean build for python-axolotl-curve25519, I have made some little changes. 
The warnings were: 
- curve25519module.c: differ in signedness [-Wpointer-sign]
- curve/ed25519/additions/curve_sigs.c, curve/ed25519/additions/zeroize.c: Removed unused variable.
- curve/ed25519/additions/zeroize.*: Redefined function definition in order to avoid function declaration isn't a     prototype warning [-Wstrict-prototypes]

The changes are minor, hope they will be helpful for you

Cheers
