### PR TITLE
Sort input file list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ sources.extend(glob("curve/ed25519/additions/*.c"))
 sources.extend(glob("curve/ed25519/nacl_sha512/*.c"))
 #headers = ['curve25519-donna.h']
 module_curve = Extension('axolotl_curve25519',
-                    sources = sources,
+                    sources = sorted(sources),
 #                   headers = headers,
                     include_dirs = [
                       'curve/ed25519/nacl_includes',


### PR DESCRIPTION
Sort input file list
so that axolotl_curve25519.so builds in a reproducible way
in spite of indeterministic filesystem readdir order
and http://bugs.python.org/issue30461

background:
While working on the reproducible builds effort, I found that
when building the python-axolotl-curve25519 package for openSUSE Linux, there were differences between each build in axolotl_curve25519.so function ordering