### PR TITLE
Release GIL while doing curve functions.

### DIFF
--- a/curve25519module.c
+++ b/curve25519module.c
@@ -47,8 +47,10 @@ calculateSignature(PyObject *self, PyObject *args)
         return NULL;
     }
 
+    Py_BEGIN_ALLOW_THREADS
     curve25519_sign((unsigned char *)signature, (unsigned char *)privatekey, 
                     (unsigned char *)message, messagelen, (unsigned char *)random);
+    Py_END_ALLOW_THREADS
 
    return PyBytes_FromStringAndSize((char *)signature, 64);
 }
@@ -59,6 +61,7 @@ verifySignature(PyObject *self, PyObject *args)
     const char *publickey;
     const char *message;
     const char *signature;
+    int result;
 
     Py_ssize_t publickeylen, messagelen, signaturelen;
 
@@ -74,11 +77,12 @@ verifySignature(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    int result = curve25519_verify((unsigned char *)signature, (unsigned char *)publickey, 
+    Py_BEGIN_ALLOW_THREADS
+    result = curve25519_verify((unsigned char *)signature, (unsigned char *)publickey, 
                                    (unsigned char *)message, messagelen);
+    Py_END_ALLOW_THREADS
 
     return Py_BuildValue("i", result);
-
 }
 
 static PyObject *
@@ -115,7 +119,9 @@ generatePublicKey(PyObject *self, PyObject *args)
         PyErr_SetString(PyExc_ValueError, "input must be 32-byte string");
         return NULL;
     }
+    Py_BEGIN_ALLOW_THREADS
     curve25519_donna(mypublic, private, basepoint);
+    Py_END_ALLOW_THREADS
     return PyBytes_FromStringAndSize((char *)mypublic, 32);
 }
 
@@ -136,7 +142,9 @@ calculateAgreement(PyObject *self, PyObject *args)
         PyErr_SetString(PyExc_ValueError, "input must be 32-byte string");
         return NULL;
     }
+    Py_BEGIN_ALLOW_THREADS
     curve25519_donna(shared_key, myprivate, theirpublic);
+    Py_END_ALLOW_THREADS
     return PyBytes_FromStringAndSize((char *)shared_key, 32);
 }
 
@@ -158,7 +166,7 @@ curve25519_functions[] = {
         PyModuleDef_HEAD_INIT,
         "axolotl_curve25519",
         NULL,
-        NULL,
+        -1,
         curve25519_functions,
     };
 


### PR DESCRIPTION
Releasing the GIL during compute intensive functions lets threaded
applications scale more effectively.  Simple benchmarks on a quad core i7
show a speed up of ~573%.

Simple benchmark used:
```python
import axolotl_curve25519 as curve
import os
import threading

randm32 = os.urandom(32)
randm64 = os.urandom(64)

private_key = curve.generatePrivateKey(randm32)
public_key = message = curve.generatePublicKey(private_key)
import time

calcs = 0

def some():
    for i in range(10000):
        curve.calculateAgreement(private_key, public_key)
        signature = curve.calculateSignature(randm64, private_key, message)
        curve.verifySignature(public_key, message, signature)
        global calcs
        calcs += 1

for test in range(3):
    print("\nTEST:", test)
    calcs = 0
    threads = [threading.Thread(target=some) for i in range(4)]
    for x in threads:
        x.start()
    s = time.time()
    for x in threads:
        x.join()
    took = time.time() - s
    print("Took", took, calcs / took)
```
