### PR TITLE
C type error in the Python module definition

### DIFF
--- a/curve25519module.c
+++ b/curve25519module.c
@@ -158,7 +158,7 @@ curve25519_functions[] = {
         PyModuleDef_HEAD_INIT,
         "axolotl_curve25519",
         NULL,
-        NULL,
+        0,
         curve25519_functions,
     };
 


### PR DESCRIPTION
The `m_size` field at this position has type `Py_ssize_t`, so you use 0 to initialize it, and not a pointer constant.  Fixes a build error with current compilers.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
